### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://blurredimages.visualstudio.com/9905f4c1-fb3c-45cf-bf87-89ed89c1fe67/14f42be9-7bcd-4c44-8148-332a66bab38d/_apis/work/boardbadge/631bc2c1-7ff8-47a3-8ee8-6401fa3d074c)](https://blurredimages.visualstudio.com/9905f4c1-fb3c-45cf-bf87-89ed89c1fe67/_boards/board/t/14f42be9-7bcd-4c44-8148-332a66bab38d/Microsoft.RequirementCategory)
 # dotfiles
 various configuration file defaults 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#17](https://blurredimages.visualstudio.com/9905f4c1-fb3c-45cf-bf87-89ed89c1fe67/_workitems/edit/17). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.